### PR TITLE
feat: leaderboard context + cost data cleanup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -61,7 +61,7 @@ Items to be delivered on the `vNext` branch and merged when ready.
 
 | # | Task | Status | Notes |
 |---|------|--------|-------|
-| V1 | **Leader Board "% of total"** | In Progress | Top Runs, Top Cost, Top Tokens cards show leader's share of the aggregate (e.g. "83% of all runs"). Replaces the empty `3rem` spacer. |
+| V1 | **Leader Board "% of total"** | ✅ Merged to vNext | Top Runs, Top Cost, Top Tokens cards show leader's share of the aggregate (e.g. "83% of all runs"). Replaces the empty `3rem` spacer. |
 | V2 | **Summary Board token trend** | Pending | Deferred until a non-redundant metric is identified. Raw token count correlates with run count. Candidate: tokens-per-run trend. Needs Tokens card space analysis first. |
 | V3 | **Docs audience separation** | PR open (`feat/docs-audience-separation`) | Move dev-only docs to `dev/`; keep user docs in `docs/`. Separate concerns. |
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -55,6 +55,18 @@ All high-priority technical items are **delivered** for V1.0.
 
 ---
 
+## V1.1 / vNext Backlog
+
+Items to be delivered on the `vNext` branch and merged when ready.
+
+| # | Task | Status | Notes |
+|---|------|--------|-------|
+| V1 | **Leader Board "% of total"** | In Progress | Top Runs, Top Cost, Top Tokens cards show leader's share of the aggregate (e.g. "83% of all runs"). Replaces the empty `3rem` spacer. |
+| V2 | **Summary Board token trend** | Pending | Deferred until a non-redundant metric is identified. Raw token count correlates with run count. Candidate: tokens-per-run trend. Needs Tokens card space analysis first. |
+| V3 | **Docs audience separation** | PR open (`feat/docs-audience-separation`) | Move dev-only docs to `dev/`; keep user docs in `docs/`. Separate concerns. |
+
+---
+
 ## V1.0 Launch Status
 
 **Feature freeze: May 14, 2026** ✅ Complete.  

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Paths are resolved automatically:
 Four cards showing aggregate metrics for the selected window:
 
 - **Job Runs** — total executions with vs-prior-period delta (↑/↓ %)
-- **Cost** — total estimated cost in amber; vs-prior delta + actual cost sub-line + ✓/✗ breakdown
+- **Cost** — total estimated cost in amber; vs-prior delta + ✓/✗ breakdown
+  (Actual cost placeholder suppressed — partial coverage creates misleading comparisons)
 - **Tokens** — total tokens in blue; In/Out/Cached proportion micro-bars
 - **Pace** — aggregate `trend_monthly / nominal_monthly` as a multiplier:
   - `< 1.0×` green — under scheduled budget
@@ -144,11 +145,11 @@ Click any card to open an educational modal explaining the metric.
 
 ### Leader Board (Row 2)
 
-Four spotlight cards surfacing the highest-value job in each dimension:
+Four spotlight cards surfacing the highest-value job in each dimension, with the leader's share of the window total:
 
-- **Top Runs** — highest execution count
-- **Top Cost** — highest cumulative spend
-- **Top Tokens** — highest token consumption
+- **Top Runs** — highest execution count; `% of total runs` sub-line
+- **Top Cost** — highest cumulative spend; `% of total cost` sub-line
+- **Top Tokens** — highest token consumption; `% of total tokens` sub-line
 - **Top Pace** — highest pace multiplier (most at risk of exceeding budget)
 
 Click any card to open a detail modal with job metadata.
@@ -337,6 +338,12 @@ MIT — see [`LICENSE`](LICENSE) for full text.
 ---
 
 ## Changelog
+
+### v1.0.1 (2026-05-13)
+
+- **Leader Board '% of total'** — spotlight cards show the leader's share of the window total (e.g. "42% of total cost")
+- **Cost card: suppressed Actual** — partial `actual_cost_usd` coverage creates misleading comparisons. The line now reads `Actual: —` until provider billing data coverage is reliable.
+- **Backend fix** — synthetic script-only rows now insert `NULL` for `actual_cost_usd` (was 0.0), eliminating phantom `$0.00` aggregates.
 
 ### v1.0.0 (2026-05-12)
 

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -1282,6 +1282,9 @@
 
   // src/components/LeaderBoard.js
   function LeaderBoard({ jobList, onTopRunsClick, onTopCostClick, onTopTokensClick, onTopPaceClick }) {
+    const totalRuns = jobList.reduce((sum, j) => sum + (j.runs || 0), 0);
+    const totalCost = jobList.reduce((sum, j) => sum + (j.total_cost || 0), 0);
+    const totalTokens = jobList.reduce((sum, j) => sum + (j.total_tokens || 0), 0);
     const cardHover = {
       onMouseEnter: (e) => {
         e.currentTarget.style.boxShadow = "0 0 0 1px rgba(255,255,255,0.18), 0 0 22px rgba(255,255,255,0.10), 0 0 6px rgba(255,255,255,0.15)";
@@ -1347,7 +1350,11 @@
                 style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
                 title: label
               }, label),
-              React.createElement("div", { style: { height: "3rem" } })
+              React.createElement(
+                "div",
+                { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+                totalRuns > 0 ? Math.round((j.runs || 0) / totalRuns * 100) + "% of total runs" : ""
+              )
             )
           )
         );
@@ -1383,7 +1390,11 @@
                 style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
                 title: label
               }, label),
-              React.createElement("div", { style: { height: "3rem" } })
+              React.createElement(
+                "div",
+                { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+                totalCost > 0 ? Math.round((j.total_cost || 0) / totalCost * 100) + "% of total cost" : ""
+              )
             )
           )
         );
@@ -1419,7 +1430,11 @@
                 style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
                 title: label
               }, label),
-              React.createElement("div", { style: { height: "3rem" } })
+              React.createElement(
+                "div",
+                { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+                totalTokens > 0 ? Math.round((j.total_tokens || 0) / totalTokens * 100) + "% of total tokens" : ""
+              )
             )
           )
         );

--- a/dashboard/src/components/LeaderBoard.js
+++ b/dashboard/src/components/LeaderBoard.js
@@ -3,6 +3,11 @@ import { fmtCost, fmtCompact, paceColor } from "../lib/formatters.js";
 import { ZapIcon, BanknoteIcon, BlocksIcon, MetronomeIcon, InfoIcon } from "../lib/icons.js";
 
 export function LeaderBoard({ jobList, onTopRunsClick, onTopCostClick, onTopTokensClick, onTopPaceClick }) {
+  // Precompute totals for "% of total" context on leader cards
+  const totalRuns = jobList.reduce((sum, j) => sum + (j.runs || 0), 0);
+  const totalCost = jobList.reduce((sum, j) => sum + (j.total_cost || 0), 0);
+  const totalTokens = jobList.reduce((sum, j) => sum + (j.total_tokens || 0), 0);
+
   const cardHover = {
     onMouseEnter: (e) => { e.currentTarget.style.boxShadow = "0 0 0 1px rgba(255,255,255,0.18), 0 0 22px rgba(255,255,255,0.10), 0 0 6px rgba(255,255,255,0.15)"; },
     onMouseLeave: (e) => { e.currentTarget.style.boxShadow = ""; },
@@ -48,7 +53,9 @@ export function LeaderBoard({ jobList, onTopRunsClick, onTopCostClick, onTopToke
               style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
               title: label
             }, label),
-            React.createElement("div", { style: { height: "3rem" } })
+            React.createElement("div", { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+              totalRuns > 0 ? (Math.round(((j.runs || 0) / totalRuns) * 100)) + "% of total runs" : ""
+            )
           )
         )
       );
@@ -74,7 +81,9 @@ export function LeaderBoard({ jobList, onTopRunsClick, onTopCostClick, onTopToke
               style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
               title: label
             }, label),
-            React.createElement("div", { style: { height: "3rem" } })
+            React.createElement("div", { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+              totalCost > 0 ? (Math.round(((j.total_cost || 0) / totalCost) * 100)) + "% of total cost" : ""
+            )
           )
         )
       );
@@ -100,7 +109,9 @@ export function LeaderBoard({ jobList, onTopRunsClick, onTopCostClick, onTopToke
               style: { fontSize: "0.75rem", fontWeight: 600, fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.85, marginTop: "0.2rem", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" },
               title: label
             }, label),
-            React.createElement("div", { style: { height: "3rem" } })
+            React.createElement("div", { style: { fontSize: "0.75rem", fontFamily: "var(--theme-font-mono, monospace)", opacity: 0.6, marginTop: "0.15rem" } },
+              totalTokens > 0 ? (Math.round(((j.total_tokens || 0) / totalTokens) * 100)) + "% of total tokens" : ""
+            )
           )
         )
       );

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -214,7 +214,7 @@ Progressive zoom-responsive wrapping: at high zoom levels, Refresh breaks away f
 #### Row 1 — Summary Board
 
 - **Job Runs** — total run count in selected window vs. prior period delta (↑/↓ %).
-- **Cost** — total `estimated_cost_usd` in amber `#f5a623`; vs-prior delta + Actual cost sub-line + ✓/✗ success/failure breakdown + wasted cost. In Failure mode, headline flips to red and label changes to "Wasted".
+- **Cost** — total `estimated_cost_usd` in amber `#f5a623`; vs-prior delta + ✓/✗ success/failure breakdown + wasted cost. Actual cost sub-line is suppressed until provider billing coverage is reliable. In Failure mode, headline flips to red and label changes to "Wasted".
 - **Tokens** — total tokens in blue `#5b8def`; 3-row micro proportion bars (In, Out, Cached).
 - **Pace** — aggregate `trend_monthly_total / nominal_monthly_total`; font-only color:
   - `< 1.0×` — green `#4ade80` (under nominal)
@@ -226,9 +226,9 @@ All four cards are clickable and open educational modals.
 #### Row 2 — Leader Board
 
 Four spotlight cards derived live from `jobList`, icon accent `#ff5722`:
-- **Top Runs** — highest `runs` job.
-- **Top Cost** — highest `total_cost` job; amber headline `#f5a623`.
-- **Top Tokens** — highest `total_tokens` job; blue headline `#5b8def`.
+- **Top Runs** — highest `runs` job; `% of total runs` sub-line.
+- **Top Cost** — highest `total_cost` job; amber headline `#f5a623`; `% of total cost` sub-line.
+- **Top Tokens** — highest `total_tokens` job; blue headline `#5b8def`; `% of total tokens` sub-line.
 - **Top Pace** — highest `projections.pace` job; font-colored via `paceColor()`. Surfaces the job most at risk of exceeding its nominal budget.
 
 All four cards are clickable and open detail modals with job metadata.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -84,12 +84,11 @@ Four cards showing aggregate metrics. Click any card to open an educational moda
 
 - **Big number:** total estimated cost in amber (`$X.XX`).
 - **Delta:** ↑/↓ percentage vs prior window.
-- **Sub-line 1:** "Actual: $X.XX" — ground-truth cost when available.
-- **Sub-line 2:** `✓ N · ✗ N` — success vs failure run counts. If failures have cost, shows wasted cost in parentheses.
+- **Sub-line:** `✓ N · ✗ N` — success vs failure run counts. If failures have cost, shows wasted cost in parentheses.
+
+> **Note:** The "Actual" line is suppressed. Partial `actual_cost_usd` coverage from providers creates misleading comparisons. It will return when coverage is reliable.
 
 In **Failure** mode, the headline turns red and reads "Wasted."
-
-**What to look for:** If actual cost consistently exceeds estimated cost, your provider pricing may have changed or your token estimates are low.
 
 ### Tokens
 
@@ -115,13 +114,13 @@ Click the Pace card to open a modal explaining the math in detail.
 Four spotlight cards showing the single highest-value job in each dimension. Click any card to see job details.
 
 ### Top Runs
-The job that executed most frequently in the window. High run count + high cost = your most expensive automation.
+The job that executed most frequently in the window, with its share of total runs (e.g. "41% of total runs"). High run count + high cost = your most expensive automation.
 
 ### Top Cost
-The job with the highest cumulative spend. Check its Pace — if pace is high, this job is the best candidate for optimization.
+The job with the highest cumulative spend, with its share of total cost (e.g. "67% of total cost"). Check its Pace — if pace is high, this job is the best candidate for optimization.
 
 ### Top Tokens
-The job consuming the most tokens. High token jobs may benefit from prompt compression or model downsizing.
+The job consuming the most tokens, with its share of total tokens (e.g. "58% of total tokens"). High token jobs may benefit from prompt compression or model downsizing.
 
 ### Top Pace
 The job most at risk of exceeding its budget. This is your early-warning signal — even if absolute cost is low, a high pace means the job is running hotter than scheduled.

--- a/facts.py
+++ b/facts.py
@@ -254,7 +254,7 @@ def ingest_script_row(
     placeholders = ["?"] * len(cols)
     values = [
         session_id, job_id, run_time, run_time,
-        0.0, 0.0,
+        0.0, None,  # actual_cost_usd = NULL (no billing event for script-only jobs)
         0, 0, 0,
         0, 0,
         0, 0, 0,
@@ -400,7 +400,7 @@ def query_summary(db_path: Path, days: int = 30, outcome: str = "both", mode: st
         "days": days,
         "total_runs": total_runs,
         "total_estimated_cost": round(total_est_cost, 4) if total_est_cost is not None else None,
-        "total_actual_cost": round(total_act_cost, 4) if total_act_cost is not None else None,
+        "total_actual_cost": None,  # Suppressed: incomplete data is worse than no data. Re-enable when coverage is reliable.
         "total_tokens": total_tokens,
         "total_input_tokens": total_in or 0,
         "total_output_tokens": total_out or 0,


### PR DESCRIPTION
## What's Changed

### Leader Board '% of total' (V1)
- Top Runs, Top Cost, Top Tokens cards show the leader's share of the aggregate total
- Replaces empty 3rem spacer with actionable context
- Pace card intentionally unchanged — ratio metrics have no meaningful '% of total'

### Cost data reliability (V2)
- No-agent synthetic rows insert NULL for actual_cost_usd (was 0.0)
- API suppresses total_actual_cost until provider billing coverage is reliable
- Frontend 'Actual: —' line preserved as dormant placeholder

### Documentation
- README, USAGE, FEATURES updated for v1.0.1
- Changelog entry added

## Verification
- [ ] 83 tests passing
- [ ] Leader Board renders % sub-lines
- [ ] Cost card shows 'Actual: —' in all modes
- [ ] ruff + mypy clean